### PR TITLE
HTTP override

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ c.SAMLAuthenticator.extract_username = extract_username
 c.JupyterHub.authenticator_class = 'jupyterhub_saml_auth.SAMLAuthenticator'
 ```
 
+### Environment variables
+
+- `SAML_HTTPS_OVERRIDE`: setting this will override the automatic detection of `http` or `https` to `/hub/acs` route and will set it to only `https`.
+
 ## Development
 
 ### Prerequisite software

--- a/jupyterhub_saml_auth/__init__.py
+++ b/jupyterhub_saml_auth/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.2.2'
+__version__ = '0.3.2'
 
 from .authenticator import SAMLAuthenticator

--- a/jupyterhub_saml_auth/handlers.py
+++ b/jupyterhub_saml_auth/handlers.py
@@ -19,8 +19,15 @@ def format_request(request):
     for key in request.arguments:
         dataDict[key] = request.arguments[key][0].decode('utf-8')
 
+    # the request may use https, however, request.protocol interpret it
+    # as http. Have an environment variable to override this at
+    # the app level in case this happens
+    https = 'off'
+    if os.environ.get('SAML_HTTPS_OVERRIDE') or request.protocol == 'https':
+        https = 'on'
+
     result = {
-        'https': 'on' if request.protocol == 'https' else 'off',
+        'https': https,
         'http_host': tornado.httputil.split_host_and_port(request.host)[0],
         'script_name': request.path,
         'server_port': tornado.httputil.split_host_and_port(request.host)[1],

--- a/jupyterhub_saml_auth/handlers.py
+++ b/jupyterhub_saml_auth/handlers.py
@@ -19,7 +19,7 @@ def format_request(request):
     for key in request.arguments:
         dataDict[key] = request.arguments[key][0].decode('utf-8')
 
-    # the request may use https, however, request.protocol interpret it
+    # the request may use https, however, request.protocol may interpret it
     # as http. Have an environment variable to override this at
     # the app level in case this happens
     https = 'off'

--- a/test/unit/test_handlers.py
+++ b/test/unit/test_handlers.py
@@ -1,6 +1,8 @@
 from tornado.httputil import HTTPServerRequest
 from jupyterhub_saml_auth.handlers import format_request
 import pytest
+import os
+
 
 @pytest.fixture()
 def mock_request():
@@ -19,7 +21,12 @@ def test_format_request_http(mock_request):
     res = format_request(mock_request)
     assert res['https'] == 'off'
 
-def test_get_reqwuest_https(mock_request):
+def test_format_request_https(mock_request):
     mock_request.protocol = 'https'
+    res = format_request(mock_request)
+    assert res['https'] == 'on'
+
+def test_format_request_https_override(mock_request):
+    os.environ['SAML_HTTPS_OVERRIDE'] = 'true'
     res = format_request(mock_request)
     assert res['https'] == 'on'


### PR DESCRIPTION
Addition of an environment variable `SAML_HTTPS_OVERRIDE` to app in order to circumvent bug in `format_request` in which the request is being detected as `http` when it's really `https`.